### PR TITLE
Add save/delete option after photo analysis

### DIFF
--- a/Features/Capture/CaptureView.swift
+++ b/Features/Capture/CaptureView.swift
@@ -29,6 +29,7 @@ struct CaptureView: View {
             // 🚀 push ResultView whenever navPath gets a UIImage
             .navigationDestination(for: UIImage.self) { img in
                 ResultView(image: img)
+                    .environmentObject(vm)
             }
             .fullScreenCover(isPresented: $vm.showCamera) {
                 CameraView(image: Binding(

--- a/Features/Result/ResultView.swift
+++ b/Features/Result/ResultView.swift
@@ -11,6 +11,8 @@ struct ResultView: View {
     let capturedImage: UIImage
     @StateObject private var vm: ResultViewModel
     @State private var peeColorIndicator: Double = 0.5
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var captureVM: CaptureViewModel
 
     init(image: UIImage) {
         self.capturedImage = image
@@ -64,6 +66,21 @@ struct ResultView: View {
                     Slider(value: $peeColorIndicator, in: 0...1)
                         .accentColor(Color.yellow)
                         .padding(.horizontal)
+
+                    HStack(spacing: 40) {
+                        Button("Delete") {
+                            captureVM.capturedImage = nil
+                            dismiss()
+                        }
+                        .foregroundColor(.red)
+
+                        Button("Save") {
+                            try? vm.persistResult()
+                            captureVM.capturedImage = nil
+                            dismiss()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- let CaptureView pass its view model into ResultView
- add Save/Delete choices after showing analysis
- delay Core Data save until user taps Save

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684591c80728832881b27c6d1db09b51